### PR TITLE
Fixes extra paren in VFL Alignment to Points section of docs

### DIFF
--- a/guides/_posts/2014-01-20-ccss.html
+++ b/guides/_posts/2014-01-20-ccss.html
@@ -187,7 +187,7 @@ Selectors are queries over a tree of HTML elements. They determine which element
 
 Please reference the [GSS Selectors Guide](/guides/selectors) for a complete list of selector and more useful information on how to use them. \*
 
-\* Note that this guide is refering to [rulesets](rulesets) which are covered next.
+\* Note that this guide is refering to [rulesets](#rulesets) which are covered next.
 
 <a name="rulesets"></a>
 ## Rulesets

--- a/guides/_posts/2014-01-5-vfl.html
+++ b/guides/_posts/2014-01-5-vfl.html
@@ -192,7 +192,7 @@ Elements can be positioned between points:
 
 {% highlight css %}
 /* VFL */
-@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right])> gap(7);
+@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right]> gap(7);
 
 /* Equivalent CCSS */
 #wall[center-x] + 7 == #poster[left];


### PR DESCRIPTION
Current version doesn't work as written
```javascript
/* VFL */
@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right])> gap(7);

/* Equivalent CCSS */
#wall[center-x] + 7 == #poster[left];
#poster[right] + 7 == #clock[left];
::window[right] - 7 == #clock[right];

```

Has an extra paren ")"
![screen shot 2015-06-10 at 10 10 42 pm](https://cloud.githubusercontent.com/assets/7946707/8100222/b966c110-0fbd-11e5-9cc1-a964f0ccae6a.png)


Throws following error:
![screen shot 2015-06-10 at 9 51 38 pm](https://cloud.githubusercontent.com/assets/7946707/8100087/f447e932-0fbb-11e5-9848-1ee1ac94bba8.png)

Fixed version without parens works:
```javascript
@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right]> gap(7);
```

![screen shot 2015-06-10 at 10 00 16 pm](https://cloud.githubusercontent.com/assets/7946707/8100103/13427988-0fbc-11e5-9e3e-308438a99ebb.png)

Awesome docs.